### PR TITLE
Add --mailbox flag to mail read command

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ pm-cli mail list --json             # JSON output
 
 ```bash
 pm-cli mail read 123                # Read message #123
+pm-cli mail read 123 -m Archive     # Read from a specific mailbox
 pm-cli mail read 123 --json         # JSON output with body
 pm-cli mail read 123 --headers      # Include all headers
 pm-cli mail read 123 --html         # Output HTML body

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -150,6 +150,7 @@ pm-cli mail read <id> [flags]
 **Flags:**
 | Flag | Description |
 |------|-------------|
+| `-m, --mailbox` | Mailbox name (defaults to configured mailbox) |
 | `--raw` | Show raw MIME source |
 | `--headers` | Include all headers |
 | `--attachments` | List attachments only |
@@ -158,6 +159,7 @@ pm-cli mail read <id> [flags]
 **Examples:**
 ```bash
 pm-cli mail read 123
+pm-cli mail read 123 -m Archive
 pm-cli mail read 123 --headers
 pm-cli mail read 123 --raw
 pm-cli mail read 123 --html            # View HTML content

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -183,6 +183,7 @@ type MailListCmd struct {
 
 type MailReadCmd struct {
 	ID          string `arg:"" help:"Message ID or sequence number"`
+	Mailbox     string `help:"Mailbox name" short:"m"`
 	Raw         bool   `help:"Show raw message"`
 	Headers     bool   `help:"Include all headers"`
 	Attachments bool   `help:"List attachments"`

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -122,6 +122,7 @@ func TestMailListCmdDefaults(t *testing.T) {
 func TestMailReadCmdOptions(t *testing.T) {
 	cmd := MailReadCmd{
 		ID:          "123",
+		Mailbox:     "Archive",
 		Raw:         true,
 		Headers:     true,
 		Attachments: true,
@@ -129,6 +130,9 @@ func TestMailReadCmdOptions(t *testing.T) {
 
 	if cmd.ID != "123" {
 		t.Errorf("ID = %q, want %q", cmd.ID, "123")
+	}
+	if cmd.Mailbox != "Archive" {
+		t.Errorf("Mailbox = %q, want %q", cmd.Mailbox, "Archive")
 	}
 	if !cmd.Raw {
 		t.Error("Raw should be true")

--- a/internal/cli/help.go
+++ b/internal/cli/help.go
@@ -134,11 +134,15 @@ func extractMailCommands() CommandSchema {
 					{Name: "id", Type: "string", Required: true, Description: "Message ID or sequence number"},
 				},
 				Flags: []FlagSchema{
+					{Name: "--mailbox", Short: "-m", Type: "string", Description: "Mailbox name (defaults to configured mailbox)"},
 					{Name: "--raw", Type: "bool", Description: "Show raw message"},
 					{Name: "--headers", Type: "bool", Description: "Include all headers"},
+					{Name: "--attachments", Type: "bool", Description: "List attachments only"},
+					{Name: "--html", Type: "bool", Description: "Output HTML body instead of plain text"},
 				},
 				Examples: []string{
 					"pm-cli mail read 123",
+					"pm-cli mail read 123 -m Archive",
 					"pm-cli mail read 123 --json",
 					"pm-cli mail read 123 --raw",
 				},

--- a/internal/cli/mail.go
+++ b/internal/cli/mail.go
@@ -126,6 +126,11 @@ func (c *MailReadCmd) Run(ctx *Context) error {
 		return fmt.Errorf("not configured - run 'pm-cli config init' first")
 	}
 
+	mailbox := c.Mailbox
+	if mailbox == "" {
+		mailbox = ctx.Config.Defaults.Mailbox
+	}
+
 	client, err := imap.NewClient(ctx.Config)
 	if err != nil {
 		return err
@@ -138,7 +143,7 @@ func (c *MailReadCmd) Run(ctx *Context) error {
 
 	// Handle --attachments flag: list attachments only
 	if c.Attachments {
-		attachments, err := client.GetAttachments(ctx.Config.Defaults.Mailbox, c.ID)
+		attachments, err := client.GetAttachments(mailbox, c.ID)
 		if err != nil {
 			return err
 		}
@@ -170,7 +175,7 @@ func (c *MailReadCmd) Run(ctx *Context) error {
 		return nil
 	}
 
-	msg, err := client.GetMessage(ctx.Config.Defaults.Mailbox, c.ID)
+	msg, err := client.GetMessage(mailbox, c.ID)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Summary

Add `-m, --mailbox` support to `mail read` so users can read messages (and list attachments) from non-default folders without changing global config.

When omitted, `mail read` still falls back to `defaults.mailbox`, so existing behavior remains unchanged.

## Changes

- `internal/cli/cli.go`
  - Add `Mailbox` flag to `MailReadCmd` (`-m`, `--mailbox`)

- `internal/cli/mail.go`
  - Resolve effective mailbox as:
    - `--mailbox` when provided
    - otherwise `config.defaults.mailbox`
  - Apply effective mailbox to both:
    - `GetMessage(...)`
    - `GetAttachments(...)`

- `internal/cli/help.go`
  - Update `mail read` command schema to include `--mailbox`
  - Add missing `--attachments` and `--html` entries for `mail read`
  - Add mailbox example (`pm-cli mail read 123 -m Archive`)

- Docs
  - `docs/commands.md`: add `--mailbox` to `mail read` flags and examples
  - `README.md`: add mailbox-specific `mail read` example

- Tests
  - `internal/cli/cli_test.go`: extend `TestMailReadCmdOptions` to cover `Mailbox`

## Why

Users often move mail into folders (Archive/custom folders). Before this change, `mail read` always targeted the configured default mailbox, making it awkward to read moved messages unless the default mailbox was changed.

## Usage

```bash
pm-cli mail read 42 -m "Folders/Investors"
pm-cli mail read 1 --mailbox Archive --json
pm-cli mail read 10 -m "Folders/Signups" --attachments
```

## Validation

- `go test ./...`
