### PR TITLE
fix(cli): nil pointer dereference in NewContext

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -5,7 +5,7 @@ import (
 	"github.com/bscott/pm-cli/internal/output"
 )
 
-var Version = "0.2.0"
+var Version = "0.2.1"
 
 type Globals struct {
 	JSON     bool   `help:"Output as JSON" name:"json"`
@@ -40,11 +40,14 @@ func NewContext(globals *Globals) (*Context, error) {
 
 	if globals.Config != "" {
 		cfg, err = config.Load(globals.Config)
+		if err != nil {
+			return nil, err
+		}
 	} else if config.Exists() {
 		cfg, err = config.Load("")
 	}
 
-	if err != nil && cfg == nil {
+	if cfg == nil {
 		cfg = config.DefaultConfig()
 	}
 

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -76,15 +76,10 @@ func TestNewContextWithConfigPath(t *testing.T) {
 		Config: "/nonexistent/config.yaml",
 	}
 
-	ctx, err := NewContext(globals)
-	// Should not error even with invalid config path; falls back to defaults
-	if err != nil {
-		t.Fatalf("NewContext() error = %v", err)
-	}
-
-	// Should have a default config
-	if ctx.Config == nil {
-		t.Error("Config should not be nil (should fall back to defaults)")
+	// Explicit config path that doesn't exist should return an error
+	_, err := NewContext(globals)
+	if err == nil {
+		t.Fatal("NewContext() should error when explicit config path does not exist")
 	}
 }
 


### PR DESCRIPTION
## Summary
- Fix nil pointer panic in `NewContext` when no config file exists and no `--config` path is provided
- `cfg` was left nil because the fallback incorrectly required `err != nil` — now defaults are assigned whenever `cfg == nil`
- Explicit `--config` with a bad path now returns an error instead of silently falling back to defaults
- Bump version to 0.2.1

## Test plan
- [x] `go test ./...` passes (was previously panicking in `TestMailListCmdRunWithoutConfig`)
- [x] `TestNewContextWithConfigPath` updated to expect error on invalid explicit path