### PR TITLE
feat(mail): env password, list enhancements, and batch command (0.2.6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-Targeted for the 0.3.0 release.
+Targeted for the 0.2.6 release.
 
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,10 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.3.0] - 2026-06-01
+## [Unreleased]
+
+Targeted for the 0.3.0 release.
+
 
 ### Added
 - `mail batch` subcommand: execute multiple label/unlabel/archive/move/flag/delete

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,18 @@
+# Changelog
+
+All notable changes to this project are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.3.0] - 2026-06-01
+
+### Added
+- `mail batch` subcommand: execute multiple label/unlabel/archive/move/flag/delete
+  operations from a JSON array over a single IMAP session, with per-op validation and
+  an optional `--stop-on-error` flag. Reported by @Juan-de-Costa-Rica (#10).
+- Server-side filtering for `mail list` (`--unread` via IMAP `SEARCH UNSEEN`, new
+  `--flagged` via `SEARCH FLAGGED`), additional envelope fields (`from_address`, `to`,
+  `message_id`, `in_reply_to`), and `--fields` selection. Reported by @Juan-de-Costa-Rica (#9).
+- `PM_CLI_BRIDGE_PASSWORD` environment variable as a fallback for the Bridge password,
+  for headless/no-keyring environments. Reported by @Juan-de-Costa-Rica (#8).

--- a/docs/batch-format.md
+++ b/docs/batch-format.md
@@ -1,0 +1,70 @@
+# Batch Operation Format
+
+`pm-cli mail batch` reads a JSON array of operations from stdin (or from a file via `--file`) and executes them in order over a single IMAP connection.
+
+## Input
+
+A JSON array of operation objects:
+
+```json
+[
+  {"op": "label",   "uids": ["uid:123"], "label": "Important"},
+  {"op": "flag",    "uids": ["uid:456"], "read": true},
+  {"op": "archive", "uids": ["uid:789"]}
+]
+```
+
+Input is limited to 10MB. An empty array, malformed JSON, or any invalid operation causes the whole batch to be rejected **before** a connection is opened — nothing is executed.
+
+## Operation fields
+
+| Field | Type | Applies to | Description |
+|-------|------|-----------|-------------|
+| `op` | string | all | One of `label`, `unlabel`, `archive`, `move`, `flag`, `delete`. **Required.** |
+| `uids` | string[] | all | Message selectors — `uid:<n>` or a bare sequence number. **Required, non-empty.** Do not mix UID and sequence selectors within one operation. |
+| `mailbox` | string | all | Source mailbox. Defaults to `INBOX`. |
+| `label` | string | `label`, `unlabel` | Label name (mapped to the `Labels/<name>` folder). **Required** for these ops. |
+| `to` | string | `move` | Destination mailbox. **Required** for `move`. |
+| `read` | bool | `flag` | Mark messages read (`\Seen`). |
+| `unread` | bool | `flag` | Mark messages unread (remove `\Seen`). |
+| `star` | bool | `flag` | Star messages (`\Flagged`). |
+| `unstar` | bool | `flag` | Unstar messages (remove `\Flagged`). |
+
+A `flag` operation requires at least one of `read`, `unread`, `star`, `unstar`.
+
+Mailbox and label names containing IMAP special characters (`{`, `*`, `%`, CR, LF) are rejected.
+
+## Operations
+
+| op | Effect |
+|----|--------|
+| `label` | Copies the messages into `Labels/<label>` (adds the label; original is kept). |
+| `unlabel` | Removes the messages from `Labels/<label>` (removes the label). |
+| `archive` | Moves the messages from `mailbox` to `Archive`. |
+| `move` | Moves the messages from `mailbox` to `to`. |
+| `flag` | Adds/removes `\Seen` / `\Flagged` per the boolean fields. |
+| `delete` | Marks the messages deleted in `mailbox` (moves to Trash; not a permanent expunge). |
+
+## Output
+
+With `--json`, the command prints per-operation results plus totals:
+
+```json
+{
+  "results": [
+    {"op": "label", "success": true},
+    {"op": "flag", "success": false, "error": "no messages matched the given ID(s) in INBOX"}
+  ],
+  "total": 2,
+  "succeeded": 1,
+  "failed": 1
+}
+```
+
+By default every operation is attempted regardless of earlier failures. Pass `--stop-on-error` to halt after the first failure (the already-attempted results are still reported).
+
+## Notes
+
+- Operations execute sequentially in array order over one connection.
+- There is no transaction/rollback: a partial batch leaves partial state. Inspect `results` to see exactly what succeeded.
+- Accurate per-operation success reporting depends on the IMAP layer detecting no-op STORE/COPY commands. See issue #11.

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -14,6 +14,12 @@ These flags are available on all commands:
 | `-v, --verbose` | Verbose output |
 | `-q, --quiet` | Suppress non-essential output |
 
+## Environment Variables
+
+| Variable | Description |
+|----------|-------------|
+| `PM_CLI_BRIDGE_PASSWORD` | Bridge password. When set (non-empty) it is used in preference to the system keyring. Intended for headless/CI environments with no secret service; interactive users should prefer the keyring (`pm-cli config init`). |
+
 ---
 
 ## config
@@ -121,11 +127,23 @@ pm-cli mail list [flags]
 | `--offset` | Skip first N messages | 0 |
 | `-p, --page` | Page number (1-based) | 0 |
 | `--unread` | Only show unread messages | false |
+| `--flagged` | Only show flagged/starred messages | false |
+| `--fields` | Comma-separated fields for JSON output | (all) |
+| `--compact` | Bare JSON array instead of wrapper object | false |
+
+**Filtering:**
+- `--unread` and `--flagged` use a server-side IMAP `SEARCH`, so the result honors `--limit` instead of being thinned out by client-side filtering. They can be combined.
 
 **Pagination:**
 - Use `--offset` to skip messages (e.g., `--offset 20` skips the 20 most recent)
 - Use `--page` for page-based navigation (e.g., `-p 2 -n 20` shows messages 21-40)
 - JSON output includes `offset`, `limit`, and `page` fields
+
+**JSON fields (`--json`):** Each message includes `uid`, `seq_num`, `from`, `from_address`, `to`, `message_id`, `in_reply_to`, `subject`, `date`, `date_iso`, `seen`, `flagged`. (`from` is the display name when present; `from_address` is always the bare address.) Empty fields are omitted.
+
+**Field selection (JSON only):**
+- `--fields` projects each message onto only the named fields, e.g. `--fields uid,subject,from_address`. Valid names: `uid`, `seq`, `from`, `from_address`, `to`, `message_id`, `in_reply_to`, `subject`, `date`, `date_iso`, `seen`, `flagged`.
+- `--compact` emits a bare JSON array (no `mailbox`/`count`/`messages` wrapper). Both flags only affect `--json` mode; text output is unchanged.
 
 **Examples:**
 ```bash
@@ -133,7 +151,12 @@ pm-cli mail list
 pm-cli mail list -n 50
 pm-cli mail list -m Sent
 pm-cli mail list --unread
+pm-cli mail list --flagged --json
 pm-cli mail list --json
+
+# Field selection
+pm-cli mail list --json --fields uid,subject,from_address
+pm-cli mail list --json --fields uid,subject --compact
 
 # Pagination
 pm-cli mail list --offset 20           # Skip 20 most recent
@@ -413,6 +436,36 @@ pm-cli mail read 123 --attachments
 # Then download by index
 pm-cli mail download 123 0
 pm-cli mail download 123 0 -o ~/Downloads/report.pdf
+```
+
+### mail batch
+
+Run multiple operations over a single IMAP session. Reads a JSON array of operations from stdin (or a file via `--file`), avoiding a fresh connection and auth round-trip per operation. Intended for automated triage that applies labels, flags, and moves to many messages per run.
+
+```bash
+pm-cli mail batch [flags]
+```
+
+**Flags:**
+| Flag | Description |
+|------|-------------|
+| `-f, --file` | Read operations from a file instead of stdin |
+| `--stop-on-error` | Stop after the first failed operation |
+
+All operations are validated up front (unknown ops, missing required fields, and IMAP special characters in names are rejected before any connection is opened). Input is capped at 10MB. Output (`--json`) reports per-operation success/failure plus totals.
+
+See [batch-format.md](batch-format.md) for the full operation schema.
+
+**Examples:**
+```bash
+# Mark a message read, then archive another, in one session
+echo '[
+  {"op": "flag",    "uids": ["uid:123"], "read": true},
+  {"op": "archive", "uids": ["uid:456"]}
+]' | pm-cli mail batch --json
+
+# Apply a label and stop on the first failure
+pm-cli mail batch --file ops.json --json --stop-on-error
 ```
 
 ### mail draft

--- a/internal/cli/batch.go
+++ b/internal/cli/batch.go
@@ -1,0 +1,210 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/bscott/pm-cli/internal/imap"
+	"github.com/bscott/pm-cli/internal/safetext"
+)
+
+// maxBatchInputSize caps batch input to guard against unbounded reads from
+// stdin or an oversized file.
+const maxBatchInputSize = 10 * 1024 * 1024 // 10 MB
+
+// batchOp is a single operation in a batch request.
+type batchOp struct {
+	Op      string   `json:"op"`
+	UIDs    []string `json:"uids"`
+	Label   string   `json:"label,omitempty"`
+	To      string   `json:"to,omitempty"`
+	Mailbox string   `json:"mailbox,omitempty"`
+	Read    bool     `json:"read,omitempty"`
+	Unread  bool     `json:"unread,omitempty"`
+	Star    bool     `json:"star,omitempty"`
+	Unstar  bool     `json:"unstar,omitempty"`
+}
+
+// batchResult reports the outcome of a single operation.
+type batchResult struct {
+	Op      string `json:"op"`
+	Success bool   `json:"success"`
+	Error   string `json:"error,omitempty"`
+}
+
+// batchOutput is the top-level JSON response.
+type batchOutput struct {
+	Results   []batchResult `json:"results"`
+	Total     int           `json:"total"`
+	Succeeded int           `json:"succeeded"`
+	Failed    int           `json:"failed"`
+}
+
+var validBatchOps = map[string]bool{
+	"label":   true,
+	"unlabel": true,
+	"archive": true,
+	"move":    true,
+	"flag":    true,
+	"delete":  true,
+}
+
+func (c *MailBatchCmd) Run(ctx *Context) error {
+	if ctx.Config.Bridge.Email == "" {
+		return fmt.Errorf("not configured - run 'pm-cli config init' first")
+	}
+
+	ops, err := readBatchOps(c.File)
+	if err != nil {
+		return err
+	}
+
+	// Validate every operation up front so malformed input fails before we
+	// open a connection or mutate any mailbox.
+	for i, op := range ops {
+		if err := validateBatchOp(i, op); err != nil {
+			return err
+		}
+	}
+
+	client, err := imap.NewClient(ctx.Config)
+	if err != nil {
+		return err
+	}
+	if err := client.Connect(); err != nil {
+		return err
+	}
+	defer client.Close()
+
+	output := batchOutput{
+		Results: make([]batchResult, 0, len(ops)),
+		Total:   len(ops),
+	}
+
+	for _, op := range ops {
+		result := executeBatchOp(client, op)
+		output.Results = append(output.Results, result)
+		if result.Success {
+			output.Succeeded++
+		} else {
+			output.Failed++
+			if c.StopOnError {
+				break
+			}
+		}
+	}
+
+	return ctx.Formatter.PrintJSON(output)
+}
+
+// readBatchOps reads and decodes the batch request from a file or stdin.
+func readBatchOps(file string) ([]batchOp, error) {
+	var r io.Reader = os.Stdin
+	if file != "" {
+		f, err := os.Open(file)
+		if err != nil {
+			return nil, fmt.Errorf("failed to open batch file: %w", err)
+		}
+		defer f.Close()
+		r = f
+	}
+
+	// Read one extra byte so we can detect input that exceeds the cap.
+	data, err := io.ReadAll(io.LimitReader(r, maxBatchInputSize+1))
+	if err != nil {
+		return nil, fmt.Errorf("failed to read input: %w", err)
+	}
+	if len(data) > maxBatchInputSize {
+		return nil, fmt.Errorf("input exceeds maximum size of %d bytes", maxBatchInputSize)
+	}
+
+	return decodeBatchOps(data)
+}
+
+// decodeBatchOps parses a JSON array of operations and rejects empty input.
+func decodeBatchOps(data []byte) ([]batchOp, error) {
+	var ops []batchOp
+	if err := json.Unmarshal(data, &ops); err != nil {
+		return nil, fmt.Errorf("invalid JSON input: %w", err)
+	}
+	if len(ops) == 0 {
+		return nil, fmt.Errorf("no operations in input")
+	}
+	return ops, nil
+}
+
+// validateBatchOp checks required fields and rejects names containing IMAP
+// special characters before any IMAP command is issued.
+func validateBatchOp(index int, op batchOp) error {
+	if !validBatchOps[op.Op] {
+		return fmt.Errorf("operation %d: unknown op %q (valid: label, unlabel, archive, move, flag, delete)", index, op.Op)
+	}
+	if len(op.UIDs) == 0 {
+		return fmt.Errorf("operation %d (%s): uids is required", index, op.Op)
+	}
+	if err := validateMailboxName(op.Mailbox); err != nil {
+		return fmt.Errorf("operation %d (%s): source %w", index, op.Op, err)
+	}
+
+	switch op.Op {
+	case "label", "unlabel":
+		if op.Label == "" {
+			return fmt.Errorf("operation %d (%s): label is required", index, op.Op)
+		}
+		if err := validateMailboxName(op.Label); err != nil {
+			return fmt.Errorf("operation %d (%s): %w", index, op.Op, err)
+		}
+	case "move":
+		if op.To == "" {
+			return fmt.Errorf("operation %d (move): to is required", index)
+		}
+		if err := validateMailboxName(op.To); err != nil {
+			return fmt.Errorf("operation %d (move): %w", index, err)
+		}
+	case "flag":
+		if !op.Read && !op.Unread && !op.Star && !op.Unstar {
+			return fmt.Errorf("operation %d (flag): at least one of read, unread, star, unstar is required", index)
+		}
+	}
+	return nil
+}
+
+// validateMailboxName rejects names containing IMAP wildcards or CR/LF. An
+// empty name is allowed (callers default it to INBOX).
+func validateMailboxName(name string) error {
+	if strings.ContainsAny(name, "{*%\r\n") {
+		return fmt.Errorf("invalid mailbox/label name %q: contains IMAP special characters", name)
+	}
+	return nil
+}
+
+func executeBatchOp(client *imap.Client, op batchOp) batchResult {
+	mailbox := op.Mailbox
+	if mailbox == "" {
+		mailbox = "INBOX"
+	}
+
+	var err error
+	switch op.Op {
+	case "label":
+		err = client.CopyMessages(mailbox, op.UIDs, "Labels/"+op.Label)
+	case "unlabel":
+		err = client.DeleteMessages("Labels/"+op.Label, op.UIDs, true)
+	case "archive":
+		err = client.MoveMessages(mailbox, op.UIDs, "Archive")
+	case "move":
+		err = client.MoveMessages(mailbox, op.UIDs, op.To)
+	case "flag":
+		err = client.SetFlagsMultiple(mailbox, op.UIDs, op.Read, op.Unread, op.Star, op.Unstar)
+	case "delete":
+		err = client.DeleteMessages(mailbox, op.UIDs, false)
+	}
+
+	if err != nil {
+		return batchResult{Op: op.Op, Error: safetext.SanitizeForTerminal(err.Error())}
+	}
+	return batchResult{Op: op.Op, Success: true}
+}

--- a/internal/cli/batch_test.go
+++ b/internal/cli/batch_test.go
@@ -1,0 +1,129 @@
+package cli
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestValidateBatchOp(t *testing.T) {
+	tests := []struct {
+		name    string
+		op      batchOp
+		wantErr string // substring expected in error, "" means no error
+	}{
+		{
+			name: "valid label",
+			op:   batchOp{Op: "label", UIDs: []string{"uid:1"}, Label: "Work"},
+		},
+		{
+			name: "valid move",
+			op:   batchOp{Op: "move", UIDs: []string{"uid:1"}, To: "Archive"},
+		},
+		{
+			name: "valid flag read",
+			op:   batchOp{Op: "flag", UIDs: []string{"uid:1"}, Read: true},
+		},
+		{
+			name: "valid delete",
+			op:   batchOp{Op: "delete", UIDs: []string{"1"}},
+		},
+		{
+			name:    "unknown op",
+			op:      batchOp{Op: "frobnicate", UIDs: []string{"1"}},
+			wantErr: "unknown op",
+		},
+		{
+			name:    "missing uids",
+			op:      batchOp{Op: "delete"},
+			wantErr: "uids is required",
+		},
+		{
+			name:    "label missing label name",
+			op:      batchOp{Op: "label", UIDs: []string{"1"}},
+			wantErr: "label is required",
+		},
+		{
+			name:    "move missing destination",
+			op:      batchOp{Op: "move", UIDs: []string{"1"}},
+			wantErr: "to is required",
+		},
+		{
+			name:    "flag with no flag set",
+			op:      batchOp{Op: "flag", UIDs: []string{"1"}},
+			wantErr: "at least one of",
+		},
+		{
+			name:    "label name with IMAP wildcard",
+			op:      batchOp{Op: "label", UIDs: []string{"1"}, Label: "bad*name"},
+			wantErr: "IMAP special characters",
+		},
+		{
+			name:    "move destination with CRLF",
+			op:      batchOp{Op: "move", UIDs: []string{"1"}, To: "Archive\r\nEVIL"},
+			wantErr: "IMAP special characters",
+		},
+		{
+			name:    "source mailbox with CRLF rejected",
+			op:      batchOp{Op: "delete", UIDs: []string{"1"}, Mailbox: "INBOX\r\nEVIL"},
+			wantErr: "IMAP special characters",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateBatchOp(0, tt.op)
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("expected error containing %q, got nil", tt.wantErr)
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Errorf("error %q does not contain %q", err.Error(), tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestValidateMailboxName(t *testing.T) {
+	valid := []string{"", "INBOX", "Labels/Work", "Some Folder", "📚 Learning"}
+	for _, name := range valid {
+		if err := validateMailboxName(name); err != nil {
+			t.Errorf("expected %q to be valid, got %v", name, err)
+		}
+	}
+
+	invalid := []string{"a*b", "a%b", "a{b", "a\rb", "a\nb"}
+	for _, name := range invalid {
+		if err := validateMailboxName(name); err == nil {
+			t.Errorf("expected %q to be rejected", name)
+		}
+	}
+}
+
+func TestReadBatchOps(t *testing.T) {
+	t.Run("valid array", func(t *testing.T) {
+		ops, err := decodeBatchOps([]byte(`[{"op":"delete","uids":["1"]}]`))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(ops) != 1 || ops[0].Op != "delete" {
+			t.Fatalf("unexpected ops: %+v", ops)
+		}
+	})
+
+	t.Run("empty array", func(t *testing.T) {
+		if _, err := decodeBatchOps([]byte(`[]`)); err == nil {
+			t.Error("expected error for empty array")
+		}
+	})
+
+	t.Run("invalid json", func(t *testing.T) {
+		if _, err := decodeBatchOps([]byte(`{not json`)); err == nil {
+			t.Error("expected error for invalid json")
+		}
+	})
+}

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -5,7 +5,7 @@ import (
 	"github.com/bscott/pm-cli/internal/output"
 )
 
-var Version = "0.3.0"
+var Version = "0.2.6"
 
 type Globals struct {
 	JSON     bool   `help:"Output as JSON" name:"json"`

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -5,7 +5,7 @@ import (
 	"github.com/bscott/pm-cli/internal/output"
 )
 
-var Version = "0.2.5"
+var Version = "0.3.0"
 
 type Globals struct {
 	JSON     bool   `help:"Output as JSON" name:"json"`
@@ -99,6 +99,12 @@ type MailCmd struct {
 	Label     LabelCmd         `cmd:"" help:"Manage message labels"`
 	Summarize MailSummarizeCmd `cmd:"" help:"Summarize message for AI processing"`
 	Extract   MailExtractCmd   `cmd:"" help:"Extract structured data from message"`
+	Batch     MailBatchCmd     `cmd:"" help:"Run multiple operations in one IMAP session (JSON from stdin)"`
+}
+
+type MailBatchCmd struct {
+	File        string `help:"Read operations from a file instead of stdin" short:"f" type:"existingfile"`
+	StopOnError bool   `help:"Stop after the first failed operation" name:"stop-on-error"`
 }
 
 type MailSummarizeCmd struct {
@@ -183,6 +189,9 @@ type MailListCmd struct {
 	Offset  int    `help:"Skip first N messages" default:"0"`
 	Page    int    `help:"Page number (1-based, combines with limit)" short:"p" default:"0"`
 	Unread  bool   `help:"Only show unread messages"`
+	Flagged bool   `help:"Only show flagged/starred messages"`
+	Fields  string `help:"Comma-separated fields to include in JSON output (e.g. uid,subject,from_address)"`
+	Compact bool   `help:"Output a bare JSON array instead of the wrapper object (JSON mode only)"`
 }
 
 type MailReadCmd struct {

--- a/internal/cli/help.go
+++ b/internal/cli/help.go
@@ -119,12 +119,19 @@ func extractMailCommands() CommandSchema {
 				Flags: []FlagSchema{
 					{Name: "--mailbox", Short: "-m", Type: "string", Default: "INBOX", Description: "Mailbox name"},
 					{Name: "--limit", Short: "-n", Type: "int", Default: "20", Description: "Number of messages to show"},
-					{Name: "--unread", Type: "bool", Description: "Only show unread messages"},
+					{Name: "--offset", Type: "int", Default: "0", Description: "Skip first N messages"},
+					{Name: "--page", Short: "-p", Type: "int", Default: "0", Description: "Page number (1-based, combines with limit)"},
+					{Name: "--unread", Type: "bool", Description: "Only show unread messages (server-side SEARCH)"},
+					{Name: "--flagged", Type: "bool", Description: "Only show flagged/starred messages (server-side SEARCH)"},
+					{Name: "--fields", Type: "string", Description: "Comma-separated fields to include in JSON output (uid,seq,from,from_address,to,message_id,in_reply_to,subject,date,date_iso,seen,flagged)"},
+					{Name: "--compact", Type: "bool", Description: "Output a bare JSON array instead of the wrapper object (JSON mode only)"},
 				},
 				Examples: []string{
 					"pm-cli mail list",
 					"pm-cli mail list --unread --json",
+					"pm-cli mail list --flagged --json",
 					"pm-cli mail list -m Sent -n 10",
+					"pm-cli mail list --json --fields uid,subject,from_address --compact",
 				},
 			},
 			{
@@ -242,6 +249,19 @@ func extractMailCommands() CommandSchema {
 					"pm-cli mail search 'meeting'",
 					"pm-cli mail search 'invoice' --from accounts@example.com",
 					"pm-cli mail search '' --since 2024-01-01 --json",
+				},
+			},
+			{
+				Name:        "mail batch",
+				Description: "Run multiple operations in one IMAP session (JSON array on stdin)",
+				Flags: []FlagSchema{
+					{Name: "--file", Short: "-f", Type: "string", Description: "Read operations from a file instead of stdin"},
+					{Name: "--stop-on-error", Type: "bool", Description: "Stop after the first failed operation"},
+				},
+				Examples: []string{
+					`echo '[{\"op\":\"flag\",\"uids\":[\"uid:123\"],\"read\":true}]' | pm-cli mail batch --json`,
+					`echo '[{\"op\":\"label\",\"uids\":[\"uid:1\"],\"label\":\"Work\"},{\"op\":\"archive\",\"uids\":[\"uid:2\"]}]' | pm-cli mail batch --json`,
+					"pm-cli mail batch --file ops.json --json --stop-on-error",
 				},
 			},
 		},

--- a/internal/cli/list_fields.go
+++ b/internal/cli/list_fields.go
@@ -1,0 +1,63 @@
+package cli
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/bscott/pm-cli/internal/imap"
+)
+
+// listFieldOrder is the canonical ordering of selectable fields, also used to
+// render the "valid fields" error message.
+var listFieldOrder = []string{
+	"uid", "seq", "from", "from_address", "to", "message_id",
+	"in_reply_to", "subject", "date", "date_iso", "seen", "flagged",
+}
+
+// fieldAccessors maps a field name to an extractor over a MessageSummary.
+var fieldAccessors = map[string]func(imap.MessageSummary) interface{}{
+	"uid":          func(m imap.MessageSummary) interface{} { return m.UID },
+	"seq":          func(m imap.MessageSummary) interface{} { return m.SeqNum },
+	"from":         func(m imap.MessageSummary) interface{} { return m.From },
+	"from_address": func(m imap.MessageSummary) interface{} { return m.FromAddress },
+	"to":           func(m imap.MessageSummary) interface{} { return m.To },
+	"message_id":   func(m imap.MessageSummary) interface{} { return m.MessageID },
+	"in_reply_to":  func(m imap.MessageSummary) interface{} { return m.InReplyTo },
+	"subject":      func(m imap.MessageSummary) interface{} { return m.Subject },
+	"date":         func(m imap.MessageSummary) interface{} { return m.Date },
+	"date_iso":     func(m imap.MessageSummary) interface{} { return m.DateISO },
+	"seen":         func(m imap.MessageSummary) interface{} { return m.Seen },
+	"flagged":      func(m imap.MessageSummary) interface{} { return m.Flagged },
+}
+
+// parseFields parses a comma-separated field list, rejecting unknown names.
+func parseFields(fieldsStr string) ([]string, error) {
+	var fields []string
+	for _, f := range strings.Split(fieldsStr, ",") {
+		f = strings.TrimSpace(f)
+		if f == "" {
+			continue
+		}
+		if _, ok := fieldAccessors[f]; !ok {
+			return nil, fmt.Errorf("unknown field %q (valid: %s)", f, strings.Join(listFieldOrder, ", "))
+		}
+		fields = append(fields, f)
+	}
+	if len(fields) == 0 {
+		return nil, fmt.Errorf("no valid fields specified")
+	}
+	return fields, nil
+}
+
+// filterMessageFields projects each message onto only the requested fields.
+func filterMessageFields(messages []imap.MessageSummary, fields []string) []map[string]interface{} {
+	result := make([]map[string]interface{}, len(messages))
+	for i, msg := range messages {
+		row := make(map[string]interface{}, len(fields))
+		for _, f := range fields {
+			row[f] = fieldAccessors[f](msg)
+		}
+		result[i] = row
+	}
+	return result
+}

--- a/internal/cli/list_fields_test.go
+++ b/internal/cli/list_fields_test.go
@@ -1,0 +1,82 @@
+package cli
+
+import (
+	"testing"
+
+	"github.com/bscott/pm-cli/internal/imap"
+)
+
+func TestParseFields(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    []string
+		wantErr bool
+	}{
+		{"single", "uid", []string{"uid"}, false},
+		{"multiple", "uid,subject,from_address", []string{"uid", "subject", "from_address"}, false},
+		{"whitespace trimmed", " uid , subject ", []string{"uid", "subject"}, false},
+		{"empty segments skipped", "uid,,subject,", []string{"uid", "subject"}, false},
+		{"unknown field", "uid,bogus", nil, true},
+		{"empty string", "", nil, true},
+		{"only commas", ",,,", nil, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseFields(tt.input)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error for %q, got none", tt.input)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if len(got) != len(tt.want) {
+				t.Fatalf("got %v, want %v", got, tt.want)
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Errorf("index %d: got %q, want %q", i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestParseFieldsAllKnown(t *testing.T) {
+	// Every field in the canonical order must have an accessor.
+	for _, f := range listFieldOrder {
+		if _, ok := fieldAccessors[f]; !ok {
+			t.Errorf("field %q listed in order but has no accessor", f)
+		}
+	}
+}
+
+func TestFilterMessageFields(t *testing.T) {
+	messages := []imap.MessageSummary{
+		{UID: 1, Subject: "Hello", From: "Alice", FromAddress: "alice@example.com"},
+		{UID: 2, Subject: "World", From: "Bob", FromAddress: "bob@example.com"},
+	}
+
+	rows := filterMessageFields(messages, []string{"uid", "from_address"})
+	if len(rows) != 2 {
+		t.Fatalf("got %d rows, want 2", len(rows))
+	}
+
+	if rows[0]["uid"] != uint32(1) {
+		t.Errorf("row 0 uid: got %v, want 1", rows[0]["uid"])
+	}
+	if rows[0]["from_address"] != "alice@example.com" {
+		t.Errorf("row 0 from_address: got %v", rows[0]["from_address"])
+	}
+	// Unselected fields must be absent, not zero-valued.
+	if _, ok := rows[0]["subject"]; ok {
+		t.Errorf("row 0 should not contain unselected field 'subject'")
+	}
+	if len(rows[0]) != 2 {
+		t.Errorf("row 0 has %d keys, want 2", len(rows[0]))
+	}
+}

--- a/internal/cli/mail.go
+++ b/internal/cli/mail.go
@@ -56,16 +56,36 @@ func (c *MailListCmd) Run(ctx *Context) error {
 		offset = (c.Page - 1) * limit
 	}
 
-	messages, err := client.ListMessages(mailbox, limit, offset, c.Unread)
+	messages, err := client.ListMessages(imap.ListOptions{
+		Mailbox:     mailbox,
+		Limit:       limit,
+		Offset:      offset,
+		UnreadOnly:  c.Unread,
+		FlaggedOnly: c.Flagged,
+	})
 	if err != nil {
 		return err
 	}
 
 	if ctx.Formatter.JSON {
+		// --fields/--compact only affect JSON output; text output is unchanged.
+		var payload interface{} = messages
+		if c.Fields != "" {
+			fields, err := parseFields(c.Fields)
+			if err != nil {
+				return err
+			}
+			payload = filterMessageFields(messages, fields)
+		}
+
+		if c.Compact {
+			return ctx.Formatter.PrintJSON(payload)
+		}
+
 		result := map[string]interface{}{
 			"mailbox":  mailbox,
 			"count":    len(messages),
-			"messages": messages,
+			"messages": payload,
 			"offset":   offset,
 			"limit":    limit,
 		}
@@ -76,12 +96,16 @@ func (c *MailListCmd) Run(ctx *Context) error {
 	}
 
 	if len(messages) == 0 {
-		fmt.Printf("No %smessages in %s\n", func() string {
-			if c.Unread {
-				return "unread "
-			}
-			return ""
-		}(), mailbox)
+		qualifier := ""
+		switch {
+		case c.Unread && c.Flagged:
+			qualifier = "unread flagged "
+		case c.Unread:
+			qualifier = "unread "
+		case c.Flagged:
+			qualifier = "flagged "
+		}
+		fmt.Printf("No %smessages in %s\n", qualifier, mailbox)
 		return nil
 	}
 
@@ -1812,7 +1836,7 @@ func (c *MailWatchCmd) populateSeenUIDs(ctx *Context, seenUIDs map[uint32]bool) 
 	defer client.Close()
 
 	// Get existing messages (reasonable limit)
-	messages, err := client.ListMessages(c.Mailbox, 100, 0, false)
+	messages, err := client.ListMessages(imap.ListOptions{Mailbox: c.Mailbox, Limit: 100})
 	if err != nil {
 		return err
 	}
@@ -1836,7 +1860,7 @@ func (c *MailWatchCmd) checkForNewMessages(ctx *Context, seenUIDs map[uint32]boo
 	defer client.Close()
 
 	// Get recent messages
-	messages, err := client.ListMessages(c.Mailbox, 50, 0, false)
+	messages, err := client.ListMessages(imap.ListOptions{Mailbox: c.Mailbox, Limit: 50})
 	if err != nil {
 		return nil, err
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -130,7 +130,15 @@ func (c *Config) SetPassword(password string) error {
 	return keyring.Set(AppName, c.Bridge.Email, password)
 }
 
+// BridgePasswordEnvVar holds the Bridge password when set, taking precedence
+// over the system keyring. This is intended for headless/CI environments where
+// no secret service is available; interactive users should prefer the keyring.
+const BridgePasswordEnvVar = "PM_CLI_BRIDGE_PASSWORD"
+
 func (c *Config) GetPassword() (string, error) {
+	if envPass := os.Getenv(BridgePasswordEnvVar); envPass != "" {
+		return envPass, nil
+	}
 	if c.Bridge.Email == "" {
 		return "", errors.New("email not configured")
 	}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -247,12 +247,41 @@ func TestSetPasswordWithoutEmail(t *testing.T) {
 }
 
 func TestGetPasswordWithoutEmail(t *testing.T) {
+	// Ensure the env var doesn't mask the no-email error path.
+	t.Setenv(BridgePasswordEnvVar, "")
 	cfg := DefaultConfig()
 	// Email is empty by default
 
 	_, err := cfg.GetPassword()
 	if err == nil {
 		t.Error("expected error when getting password without email")
+	}
+}
+
+func TestGetPasswordFromEnvVar(t *testing.T) {
+	cfg := DefaultConfig()
+	t.Setenv(BridgePasswordEnvVar, "env-secret-123")
+
+	password, err := cfg.GetPassword()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if password != "env-secret-123" {
+		t.Errorf("got %q, want %q", password, "env-secret-123")
+	}
+}
+
+func TestGetPasswordEnvVarTakesPrecedence(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.Bridge.Email = "test@example.com"
+	t.Setenv(BridgePasswordEnvVar, "env-wins")
+
+	password, err := cfg.GetPassword()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if password != "env-wins" {
+		t.Errorf("got %q, want %q", password, "env-wins")
 	}
 }
 

--- a/internal/imap/client.go
+++ b/internal/imap/client.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -228,8 +229,12 @@ func (c *Client) SelectMailbox(name string) (*MailboxStatus, error) {
 	}, nil
 }
 
-func (c *Client) ListMessages(mailbox string, limit, offset int, unreadOnly bool) ([]MessageSummary, error) {
-	status, err := c.SelectMailbox(mailbox)
+func (c *Client) ListMessages(opts ListOptions) ([]MessageSummary, error) {
+	if opts.Limit <= 0 {
+		opts.Limit = 20
+	}
+
+	status, err := c.SelectMailbox(opts.Mailbox)
 	if err != nil {
 		return nil, err
 	}
@@ -238,22 +243,59 @@ func (c *Client) ListMessages(mailbox string, limit, offset int, unreadOnly bool
 		return []MessageSummary{}, nil
 	}
 
-	// Calculate the range of messages to fetch (most recent first, with offset)
-	// offset=0: get the last `limit` messages
-	// offset=20: skip the 20 most recent, get the next `limit`
-	total := int(status.Messages)
-	end := total - offset
-	if end <= 0 {
-		return []MessageSummary{}, nil
-	}
-	start := end - limit + 1
-	if start < 1 {
-		start = 1
-	}
-
-	// Build sequence set for range
+	// Build the sequence set of messages to fetch. When filtering by flags we
+	// ask the server to do the work (SEARCH), so the returned count honors the
+	// requested limit instead of being thinned out by client-side filtering.
 	var seqSet imap.SeqSet
-	seqSet.AddRange(uint32(start), uint32(end))
+	if opts.UnreadOnly || opts.FlaggedOnly {
+		criteria := &imap.SearchCriteria{}
+		if opts.UnreadOnly {
+			criteria.NotFlag = append(criteria.NotFlag, imap.FlagSeen)
+		}
+		if opts.FlaggedOnly {
+			criteria.Flag = append(criteria.Flag, imap.FlagFlagged)
+		}
+
+		searchCmd := c.client.Search(criteria, nil)
+		searchData, err := searchCmd.Wait()
+		if err != nil {
+			return nil, fmt.Errorf("search failed: %w", err)
+		}
+
+		seqNums := searchData.AllSeqNums()
+		if len(seqNums) == 0 {
+			return []MessageSummary{}, nil
+		}
+
+		// Newest first: SEARCH returns ascending sequence numbers, so sort
+		// descending before applying offset/limit (skip the most recent first).
+		sort.Slice(seqNums, func(i, j int) bool { return seqNums[i] > seqNums[j] })
+
+		if opts.Offset >= len(seqNums) {
+			return []MessageSummary{}, nil
+		}
+		endIdx := opts.Offset + opts.Limit
+		if endIdx > len(seqNums) {
+			endIdx = len(seqNums)
+		}
+		for _, seq := range seqNums[opts.Offset:endIdx] {
+			seqSet.AddNum(seq)
+		}
+	} else {
+		// Calculate the range of messages to fetch (most recent first, with offset)
+		// offset=0: get the last `limit` messages
+		// offset=20: skip the 20 most recent, get the next `limit`
+		total := int(status.Messages)
+		end := total - opts.Offset
+		if end <= 0 {
+			return []MessageSummary{}, nil
+		}
+		start := end - opts.Limit + 1
+		if start < 1 {
+			start = 1
+		}
+		seqSet.AddRange(uint32(start), uint32(end))
+	}
 
 	// Fetch options
 	fetchOptions := &imap.FetchOptions{
@@ -303,7 +345,6 @@ func (c *Client) ListMessages(mailbox string, limit, offset int, unreadOnly bool
 			continue
 		}
 
-		// Check if unread only
 		seen := false
 		flagged := false
 		for _, f := range flags {
@@ -315,29 +356,41 @@ func (c *Client) ListMessages(mailbox string, limit, offset int, unreadOnly bool
 			}
 		}
 
-		if unreadOnly && seen {
-			continue
-		}
-
 		from := ""
+		fromAddress := ""
 		if len(envelope.From) > 0 {
 			addr := envelope.From[0]
+			fromAddress = addr.Addr()
 			if addr.Name != "" {
 				from = addr.Name
 			} else {
-				from = addr.Addr()
+				from = fromAddress
 			}
 		}
 
+		var to []string
+		for _, addr := range envelope.To {
+			to = append(to, addr.Addr())
+		}
+
+		inReplyTo := ""
+		if len(envelope.InReplyTo) > 0 {
+			inReplyTo = envelope.InReplyTo[0]
+		}
+
 		summary := MessageSummary{
-			UID:     uint32(uid),
-			SeqNum:  msg.SeqNum,
-			From:    from,
-			Subject: envelope.Subject,
-			Date:    date,
-			DateISO: dateISO,
-			Seen:    seen,
-			Flagged: flagged,
+			UID:         uint32(uid),
+			SeqNum:      msg.SeqNum,
+			From:        from,
+			FromAddress: fromAddress,
+			To:          to,
+			MessageID:   envelope.MessageID,
+			InReplyTo:   inReplyTo,
+			Subject:     envelope.Subject,
+			Date:        date,
+			DateISO:     dateISO,
+			Seen:        seen,
+			Flagged:     flagged,
 		}
 
 		messages = append(messages, summary)
@@ -661,24 +714,40 @@ func (c *Client) Search(mailbox string, opts SearchOptions) ([]MessageSummary, e
 		}
 
 		fromStr := ""
+		fromAddress := ""
 		if len(envelope.From) > 0 {
 			addr := envelope.From[0]
+			fromAddress = addr.Addr()
 			if addr.Name != "" {
 				fromStr = addr.Name
 			} else {
-				fromStr = addr.Addr()
+				fromStr = fromAddress
 			}
 		}
 
+		var to []string
+		for _, addr := range envelope.To {
+			to = append(to, addr.Addr())
+		}
+
+		inReplyTo := ""
+		if len(envelope.InReplyTo) > 0 {
+			inReplyTo = envelope.InReplyTo[0]
+		}
+
 		summary := MessageSummary{
-			UID:     uint32(uid),
-			SeqNum:  msg.SeqNum,
-			From:    fromStr,
-			Subject: envelope.Subject,
-			Date:    envelope.Date.Format("2006-01-02 15:04"),
-			DateISO: envelope.Date.Format(time.RFC3339),
-			Seen:    seen,
-			Flagged: flagged,
+			UID:         uint32(uid),
+			SeqNum:      msg.SeqNum,
+			From:        fromStr,
+			FromAddress: fromAddress,
+			To:          to,
+			MessageID:   envelope.MessageID,
+			InReplyTo:   inReplyTo,
+			Subject:     envelope.Subject,
+			Date:        envelope.Date.Format("2006-01-02 15:04"),
+			DateISO:     envelope.Date.Format(time.RFC3339),
+			Seen:        seen,
+			Flagged:     flagged,
 		}
 
 		messages = append(messages, summary)
@@ -1343,7 +1412,7 @@ func (c *Client) UpdateDraft(id string, draft *Draft) (uint32, error) {
 
 // ListDrafts returns drafts from the Drafts folder
 func (c *Client) ListDrafts(limit int) ([]MessageSummary, error) {
-	return c.ListMessages("Drafts", limit, 0, false)
+	return c.ListMessages(ListOptions{Mailbox: "Drafts", Limit: limit})
 }
 
 // GetDraft retrieves a specific draft

--- a/internal/imap/types.go
+++ b/internal/imap/types.go
@@ -14,14 +14,28 @@ type MailboxStatus struct {
 }
 
 type MessageSummary struct {
-	UID     uint32 `json:"uid"`
-	SeqNum  uint32 `json:"seq_num"`
-	From    string `json:"from"`
-	Subject string `json:"subject"`
-	Date    string `json:"date"`
-	DateISO string `json:"date_iso,omitempty"`
-	Seen    bool   `json:"seen"`
-	Flagged bool   `json:"flagged"`
+	UID         uint32   `json:"uid"`
+	SeqNum      uint32   `json:"seq_num"`
+	From        string   `json:"from"`
+	FromAddress string   `json:"from_address,omitempty"`
+	To          []string `json:"to,omitempty"`
+	MessageID   string   `json:"message_id,omitempty"`
+	InReplyTo   string   `json:"in_reply_to,omitempty"`
+	Subject     string   `json:"subject"`
+	Date        string   `json:"date"`
+	DateISO     string   `json:"date_iso,omitempty"`
+	Seen        bool     `json:"seen"`
+	Flagged     bool     `json:"flagged"`
+}
+
+// ListOptions controls ListMessages behavior. A zero or negative Limit
+// defaults to 20.
+type ListOptions struct {
+	Mailbox     string
+	Limit       int
+	Offset      int
+	UnreadOnly  bool
+	FlaggedOnly bool
 }
 
 type Message struct {


### PR DESCRIPTION
Implements three feature requests (#8, #9, #10) for automated/headless email workflows. Reimplemented from scratch (issue branches used only as reference); builds clean, `go vet` clean, all tests pass.

## #8 — Bridge password from env var
- `GetPassword()` checks `PM_CLI_BRIDGE_PASSWORD` before the system keyring → enables headless/CI use with no secret service.
- Interactive use unchanged (env var only consulted when set & non-empty). Env-takes-precedence is documented.

## #9 — `mail list` enhancements
- **Fixes the `--unread` undercount:** `--unread`/`--flagged` now use server-side IMAP `SEARCH`, so results honor `--limit` instead of being thinned by client-side filtering. The two can be combined.
- Adds `from_address`, `to`, `message_id`, `in_reply_to` to list/search JSON (all already in the ENVELOPE — zero extra fetch). Previously `from` dropped the address whenever a display name was present.
- Adds `--fields` (project onto named JSON fields) and `--compact` (bare array). JSON-only; text output unchanged.
- `ListMessages` now takes a `ListOptions` struct; all callers updated.

## #10 — `mail batch`
- New `mail batch` subcommand runs a JSON array of ops (`label`, `unlabel`, `archive`, `move`, `flag`, `delete`) over a single IMAP session.
- All ops validated **before** connecting; names with IMAP special chars rejected — **including the source `mailbox`** (closed a gap vs. the original proposal); 10MB input cap; errors sanitized via `safetext`.
- `--stop-on-error` halts after first failure; per-op results + totals reported.

## Tests & docs
- New tests: env-var precedence, field parsing/projection, batch validation (incl. CRLF/wildcard rejection) and decode.
- `docs/commands.md`, new `docs/batch-format.md`, and the `--help-json` schema updated. Version bumped to 0.2.6.

## ⚠️ Sequencing note
`mail batch` routes through `CopyMessages`/`DeleteMessages`/`MoveMessages`. Its per-op success reporting is only fully accurate once **#11** (silent no-op detection in STORE/COPY) lands — and #11's COPY check still needs the `UIDPLUS`/`COPYUID` verification flagged in that review. Recommend landing #11 before relying on batch's `label`/`unlabel` results.

---
_Supersedes #12 (closed automatically when its branch was renamed to `v0.2.6`)._
